### PR TITLE
`nvim-treesitter` fix

### DIFF
--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -28,7 +28,6 @@ return {
       "javascript",
       "jsdoc",
       "json",
-      "jsonc",
       "lua",
       "luadoc",
       "luap",


### PR DESCRIPTION

I'm disabling `jsonc` from the list of
supported languages.

Signed-off-by: Mesi Rendon <hello@mesirendon.com>
